### PR TITLE
TIM_13 CH1 PP1 pin corrected

### DIFF
--- a/00-STM32F429_LIBRARIES/tm_stm32f4_pwm.c
+++ b/00-STM32F429_LIBRARIES/tm_stm32f4_pwm.c
@@ -1011,7 +1011,7 @@ TM_PWM_Result_t TM_PWM_INT_InitTIM13Pins(TM_PWM_Channel_t Channel, TM_PWM_PinsPa
 			switch (PinsPack) {
 				case TM_PWM_PinsPack_1:
 #ifdef GPIOA
-					TM_GPIO_InitAlternate(GPIOA, GPIO_PIN_1, TM_GPIO_OType_PP, TM_GPIO_PuPd_NOPULL, TM_GPIO_Speed_High, GPIO_AF_TIM13);
+					TM_GPIO_InitAlternate(GPIOA, GPIO_PIN_6, TM_GPIO_OType_PP, TM_GPIO_PuPd_NOPULL, TM_GPIO_Speed_High, GPIO_AF_TIM13);
 					result = TM_PWM_Result_Ok;
 #endif
 					break;


### PR DESCRIPTION
TIM_13 CH1 PP1 pin was previously pin 1 which was not correct. so it is changed with correct pin. i.e. GPIO_PIN_6