### PR TITLE
Data receving fixed in 'TM_I2C_ReadMultiNoRegister'.

### DIFF
--- a/00-STM32F429_LIBRARIES/tm_stm32f4_i2c.c
+++ b/00-STM32F429_LIBRARIES/tm_stm32f4_i2c.c
@@ -148,9 +148,9 @@ TM_I2C_ReadMultiNoRegister(I2C_TypeDef* I2Cx, uint8_t address, uint8_t* data, ui
     while (count--) {
         if (!count) {
             /* Last byte */
-            *data = TM_I2C_ReadNack(I2Cx);
+            *data++ = TM_I2C_ReadNack(I2Cx);
         } else {
-            *data = TM_I2C_ReadAck(I2Cx);
+            *data++ = TM_I2C_ReadAck(I2Cx);
         }
     }
 }


### PR DESCRIPTION
The function 'ReadMultiNoRegister' was not working as intended, the data pointer was not incremented, thus all the data was written to data[0].
Also I think that there should be a 'TM_I2C_Stop' when all the data is resaved. But it is working without.